### PR TITLE
Update create_hideout_composition.sqf, Update rescue.sqf, Modified create.sqf and hd_cache.sqf

### DIFF
--- a/core/fnc/cache/create.sqf
+++ b/core/fnc/cache/create.sqf
@@ -53,3 +53,11 @@ if (btc_debug) then {
     _marker setMarkerText format ["Cache %1", btc_cache_n];
     _marker setMarkerSize [0.8, 0.8];
 };
+
+sleep 600;
+
+_cacheMarkerPos = [btc_cache_obj, 5, 20, 0, 0, 25, 0] call BIS_fnc_findSafePos;
+_cacheMarker = createMarker ["CacheMarker_01", _cacheMarkerPos];
+"CacheMarker_01" setMarkerShape "ELLIPSE";
+"CacheMarker_01" setMarkerColor "ColorRed";
+"CacheMarker_01" setMarkerSize [20, 20]; 

--- a/core/fnc/cache/hd_cache.sqf
+++ b/core/fnc/cache/hd_cache.sqf
@@ -70,6 +70,8 @@ if (isNil {_cache getVariable "btc_hd_cache"} && {_explosive} && {_damage > 0.6}
     btc_cache_info = btc_info_cache_def;
     btc_cache_markers = [];
 
+    deleteMarker "CacheMarker_01";
+
     //Notification
     [0] remoteExec ["btc_fnc_show_hint", 0];
 

--- a/core/fnc/mil/create_hideout_composition.sqf
+++ b/core/fnc/mil/create_hideout_composition.sqf
@@ -24,7 +24,7 @@ params [
     ["_pos", [0, 0, 0], [[]]]
 ];
 
-private _type_bigbox = selectRandom ["Box_FIA_Ammo_F", "C_supplyCrate_F", "Box_East_AmmoVeh_F"];
+private _type_bigbox = selectRandom ["Box_FIA_Ammo_F", "C_supplyCrate_F"];
 
 private _composition_hideout = [
     [selectRandom btc_type_campfire,0,[-2.30957,-1.02979,0]],
@@ -32,21 +32,15 @@ private _composition_hideout = [
     [selectRandom btc_type_bigbox,227.166,[2.66504,1.4126,0]],
     [selectRandom btc_type_sleepingbag,135.477,[0.758789,-3.91309,0]],
     [selectRandom btc_type_power,77.6499,[0.418945,3.51855,0]],
-    [selectRandom btc_type_seat,171.123,[-2.08203,-3.39795,0]],
-    ["Flag_Red_F",0,[0,0,0]],
+    ["ISC_Flag_IS",0,[0,0,0]],
     [selectRandom btc_type_sleepingbag,161.515,[-0.726563,-4.76953,0]],
     ["Land_SatelliteAntenna_01_F",304.749,[-3.71973,2.46143,0]],
     [selectRandom btc_type_seat,279.689,[-4.52783,-0.76416,0]],
     [selectRandom btc_type_seat,238.639,[-3.89014,-2.94873,0]],
-    [selectRandom btc_type_bigbox,346.664,[3.66455,-1.72998,0]],
-    [selectRandom btc_type_box,36.4913,[-2.65088,-4.5625,0]],
     [selectRandom btc_type_tent,86.984,[3.19922,-4.36133,0]],
-    [selectRandom btc_type_tent,10,[-4.35303,-5.66309,0]],
-    [selectRandom btc_type_tent,300,[-8.47949,-1.64063,0]]
+    [selectRandom btc_type_tent,10,[-4.35303,-5.66309,0]]
+
 ];
-if (random 1 > 0.5) then {
-    _composition_hideout pushBack [selectRandom btc_type_camonet,0,[-0.84668,-2.16113,0]];
-};
 
 private _composition = [_pos, random 360, _composition_hideout] call btc_fnc_create_composition;
 

--- a/core/fnc/side/rescue.sqf
+++ b/core/fnc/side/rescue.sqf
@@ -48,6 +48,16 @@ _heli setVariable ["ace_cookoff_enableAmmoCookoff", false, true];
 _heli setDamage 1;
 _heli enableSimulation false;
 _heli setPos [getPosASL _heli select 0, getPosASL _heli select 1, 0 - 1.5];
+
+
+_attackPos_01 = [_heli, 1000, 1500, 5, 0, 25, 0] call BIS_fnc_findSafePos;
+_attackGroup_01 = [_attackPos_01, east, (configfile >> "CfgGroups" >> "East" >> "CFP_O_IS" >> "Infantry" >> "cfp_o_grp_is_inf_fire_team")] call BIS_fnc_spawnGroup;
+_attackwp_01 = _attackGroup_01 addWaypoint [position _heli, 0];
+
+_attackPos_02 = [_heli, 1000, 1500, 5, 0, 25, 0] call BIS_fnc_findSafePos;
+_attackGroup_02 = [_attackPos_02, east, (configfile >> "CfgGroups" >> "East" >> "CFP_O_IS" >> "Infantry" >> "cfp_o_grp_is_inf_fire_team")] call BIS_fnc_spawnGroup;
+_attackwp_02 = _attackGroup_02 addWaypoint [position _heli, 0];
+
 private _pitch = if (random 1 > 0.5) then {
     random 40
 } else {


### PR DESCRIPTION
Adjusted hideout composition size as requested in issue #8.

Included hostile assault teams in rescue.sqf as requested in issue #9.

Modified both create.sqf and hd_cache.sqf to incorporate a cache marker as requested in issue #5.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |
| Fixed issues | #8 #9 #5  |

### Description:

Issue #5  :
-Modified both create.sqf and hd_cache.sqf to incorporate a 20 x 20m cache marker that spawns near, not directly on, the cache after ten minutes to guide the players to it's rough location. Players will still need to search the area to find the cache.

The marker will then be deleted once the cache is destroyed.

Issue #8 :
-Adjusted size of hideout composition by reducing the object pool in the .sqf.

-Removed camo net, as during testing it was always destroyed upon spawning anyway.

-Replaced default hideout red flag with ISIS flag.

Issue #9 :
-Added x 2 enemy fireteams that spawn in 1000 - 1500m from downed heli then make their way in towards it. Could not figure out the proper format for the send fnc so just wrote my own.

### Successfully tested on:
- [x ] Local Server

### Compatibility checked with:
* TFR Standard Mod List
